### PR TITLE
Address interface ordering issue

### DIFF
--- a/com/macros/support/src/utils/idents.rs
+++ b/com/macros/support/src/utils/idents.rs
@@ -45,8 +45,9 @@ pub fn base_interface_idents(attr_args: &AttributeArgs) -> Vec<Ident> {
 
             for item in &attr.nested {
                 if let NestedMeta::Meta(Meta::Path(p)) = item {
-                    assert!(
-                        p.segments.len() == 1,
+                    assert_eq!(
+                        p.segments.len(),
+                        1,
                         "Incapable of handling multiple path segments yet."
                     );
                     base_interface_idents.push(
@@ -59,6 +60,22 @@ pub fn base_interface_idents(attr_args: &AttributeArgs) -> Vec<Ident> {
                 }
             }
         }
+    }
+
+    if base_interface_idents.contains(&format_ident!("IComponent")) {
+        assert_eq!(
+            base_interface_idents[0],
+            format_ident!("IComponent"),
+            "IComponent should always be first."
+        );
+    }
+
+    if base_interface_idents.contains(&format_ident!("IEditController")) {
+        assert_eq!(
+            base_interface_idents[0],
+            format_ident!("IEditController"),
+            "IEditController should always be first."
+        );
     }
 
     base_interface_idents
@@ -92,8 +109,9 @@ pub fn get_aggr_map(attr_args: &AttributeArgs) -> HashMap<Ident, Vec<Ident>> {
 
             for item in &attr.nested {
                 if let NestedMeta::Meta(Meta::Path(p)) = item {
-                    assert!(
-                        p.segments.len() == 1,
+                    assert_eq!(
+                        p.segments.len(),
+                        1,
                         "Incapable of handling multiple path segments yet."
                     );
                     aggr_interfaces_idents.push(

--- a/com/macros/support/src/utils/idents.rs
+++ b/com/macros/support/src/utils/idents.rs
@@ -68,9 +68,7 @@ pub fn base_interface_idents(attr_args: &AttributeArgs) -> Vec<Ident> {
             format_ident!("IComponent"),
             "IComponent should always be first."
         );
-    }
-
-    if base_interface_idents.contains(&format_ident!("IEditController")) {
+    } else if base_interface_idents.contains(&format_ident!("IEditController")) {
         assert_eq!(
             base_interface_idents[0],
             format_ident!("IEditController"),

--- a/examples/passthru.rs
+++ b/examples/passthru.rs
@@ -36,8 +36,6 @@ unsafe fn wstrcpy(src: &str, dst: *mut c_short) {
 }
 
 #[VST3(implements(
-    IComponent,
-    IPluginBase,
     IEditController,
     IAudioProcessor,
     IAutomationState,

--- a/examples/passthru.rs
+++ b/examples/passthru.rs
@@ -36,6 +36,7 @@ unsafe fn wstrcpy(src: &str, dst: *mut c_short) {
 }
 
 #[VST3(implements(
+    IComponent,
     IEditController,
     IAudioProcessor,
     IAutomationState,


### PR DESCRIPTION
This is an early attempt to address the issue #14 

I think it's a better idea to launch an error instead of correcting it under the hood, mainly to keep the ordering in the source code of the implementer consistent with that of other VST3 libraries or wrappers.

I'm open to suggestions for what concerns the code itself and also the message that should be launched to the users of this crate.