### PR TITLE
Added missing enums

### DIFF
--- a/src/vst/ivstnoteexpression.rs
+++ b/src/vst/ivstnoteexpression.rs
@@ -2,6 +2,21 @@ use crate::base::{tchar, tresult};
 use vst3_com::com_interface;
 use vst3_com::interfaces::iunknown::IUnknown;
 
+pub enum NoteExpressionTypeID
+{
+	kVolumeTypeID = 0,
+	kPanTypeID = 1,
+	kTuningTypeID = 2,
+	kVibratoTypeID = 3,
+	kExpressionTypeID = 4,
+	kBrightnessTypeID = 5,
+	kTextTypeID = 6,
+	kPhonemeTypeID = 7,
+	kCustomStart = 100000,
+	kCustomEnd = 200000,
+	kInvalidTypeID = 0xFFFFFFFF
+}
+
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct NoteExpressionValueDescription {
@@ -14,7 +29,7 @@ pub struct NoteExpressionValueDescription {
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct NoteExpressionValueEvent {
-    pub type_id: u32,
+    pub type_id: NoteExpressionTypeID,
     pub note_id: i32,
     pub value: f64,
 }
@@ -22,7 +37,7 @@ pub struct NoteExpressionValueEvent {
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub struct NoteExpressionTextEvent {
-    pub type_id: u32,
+    pub type_id: NoteExpressionTypeID,
     pub note_id: i32,
     pub text_len: u32,
     pub text: *const tchar,
@@ -31,7 +46,7 @@ pub struct NoteExpressionTextEvent {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct NoteExpressionTypeInfo {
-    pub type_id: u32,
+    pub type_id: NoteExpressionTypeID,
     pub title: [tchar; 128],
     pub short_title: [tchar; 128],
     pub units: [tchar; 128],
@@ -41,10 +56,18 @@ pub struct NoteExpressionTypeInfo {
     pub flags: i32,
 }
 
+pub enum KeySwitchTypeID
+{
+	kNoteOnKeyswitchTypeID = 0,
+	kOnTheFlyKeyswitchTypeID = 1,	
+	kOnReleaseKeyswitchTypeID = 2,
+	kKeyRangeTypeID = 3
+}
+
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct KeySwitchInfo {
-    pub type_id: u32,
+    pub type_id: KeySwitchTypeID,
     pub title: [tchar; 128],
     pub short_title: [tchar; 128],
     pub keyswitch_min: i32,


### PR DESCRIPTION
NoteExpressionTypeID, KeySwitchTypeID. Replaced u32 type for type_id params with respective enum types as found in the SDK.
The NoteExpressionTypeID is used in ivstphysicalui.rs as well.