### PR TITLE
Add a thin/transparent wrapper around raw vtable pointers in instances

### DIFF
--- a/src/base/icloneable.rs
+++ b/src/base/icloneable.rs
@@ -1,6 +1,7 @@
+use crate::utils::VstPtr;
 use vst3_com::{com_interface, interfaces::iunknown::IUnknown};
 
 #[com_interface("D45406B9-3A2D-4443-9DAD-9BA985A1454B")]
 pub trait ICloneable: IUnknown {
-    unsafe fn clone(&self) -> *mut dyn IUnknown;
+    unsafe fn clone(&self) -> VstPtr<dyn IUnknown>;
 }

--- a/src/base/ierrorcontext.rs
+++ b/src/base/ierrorcontext.rs
@@ -1,10 +1,12 @@
 use super::IUnknown;
 use crate::base::{tresult, IString};
+use crate::utils::VstPtr;
+
 use vst3_com::com_interface;
 
 #[com_interface("12BCD07B-7C69-4336-B7DA-77C3444A0CD0")]
 pub trait IErrorContext: IUnknown {
     unsafe fn disable_error_ui(&self, state: bool);
     unsafe fn error_message_shown(&self) -> tresult;
-    unsafe fn get_error_message(&self, message: *mut dyn IString) -> tresult;
+    unsafe fn get_error_message(&self, message: VstPtr<dyn IString>) -> tresult;
 }

--- a/src/base/iupdatehandler.rs
+++ b/src/base/iupdatehandler.rs
@@ -1,4 +1,6 @@
 use crate::base::tresult;
+use crate::utils::VstPtr;
+
 use vst3_com::com_interface;
 use vst3_com::interfaces::iunknown::IUnknown;
 
@@ -6,21 +8,21 @@ use vst3_com::interfaces::iunknown::IUnknown;
 pub trait IUpdateHandler: IUnknown {
     unsafe fn add_dependent(
         &self,
-        object: *mut dyn IUnknown,
-        dependent: *mut dyn IDependent,
+        object: VstPtr<dyn IUnknown>,
+        dependent: VstPtr<dyn IDependent>,
     ) -> tresult;
     unsafe fn remove_dependent(
         &self,
-        object: *mut dyn IUnknown,
-        dependent: *mut dyn IDependent,
+        object: VstPtr<dyn IUnknown>,
+        dependent: VstPtr<dyn IDependent>,
     ) -> tresult;
-    unsafe fn trigger_updates(&self, object: *mut dyn IUnknown, message: i32) -> tresult;
-    unsafe fn defer_updates(&self, object: *mut dyn IUnknown, message: i32) -> tresult;
+    unsafe fn trigger_updates(&self, object: VstPtr<dyn IUnknown>, message: i32) -> tresult;
+    unsafe fn defer_updates(&self, object: VstPtr<dyn IUnknown>, message: i32) -> tresult;
 }
 
 #[com_interface("F52B7AAE-DE72-416d-8AF1-8ACE9DD7BD5E")]
 pub trait IDependent: IUnknown {
-    unsafe fn update(&self, changed_unknown: *mut dyn IUnknown, message: i32);
+    unsafe fn update(&self, changed_unknown: VstPtr<dyn IUnknown>, message: i32);
 }
 
 pub const kWillChange: i32 = 0;

--- a/src/gui/iplugview.rs
+++ b/src/gui/iplugview.rs
@@ -1,4 +1,5 @@
 use crate::base::{char16, tresult, FIDString, TBool};
+use crate::utils::VstPtr;
 use vst3_com::interfaces::iunknown::IUnknown;
 use vst3_com::{c_void, com_interface};
 
@@ -27,7 +28,7 @@ pub trait IPlugView: IUnknown {
 
 #[com_interface("367FAF01-AFA9-4693-8D4D-A2A0ED0882A3")]
 pub trait IPlugFrame: IUnknown {
-    unsafe fn resize_view(&self, view: *mut dyn IPlugView, new_size: *mut ViewRect) -> tresult;
+    unsafe fn resize_view(&self, view: VstPtr<dyn IPlugView>, new_size: *mut ViewRect) -> tresult;
 }
 
 #[cfg(linux)]
@@ -53,11 +54,12 @@ pub mod linux {
     pub trait IRunLoop: IUnknown {
         unsafe fn register_event_handler(
             &self,
-            h: *mut dyn IEventHandler,
+            h: VstPtr<IEventHandler>,
             fd: FileDescriptor,
         ) -> tresult;
-        unsafe fn unregister_event_handler(&self, h: *mut dyn IEventHandler) -> tresult;
-        unsafe fn register_timer(&self, t: *mut dyn ITimerHandler, ms: TimerInterval) -> tresult;
-        unsafe fn unregister_timer(&self, t: *mut dyn ITimerHandler) -> tresult;
+        unsafe fn unregister_event_handler(&self, h: VstPtr<dyn IEventHandler>) -> tresult;
+        unsafe fn register_timer(&self, t: VstPtr<dyn ITimerHandler>, ms: TimerInterval)
+            -> tresult;
+        unsafe fn unregister_timer(&self, t: VstPtr<dyn ITimerHandler>) -> tresult;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,4 +13,3 @@ pub use vst3_com::co_class as VST3;
 pub use vst3_com::REFIID;
 pub use vst3_com::*;
 pub mod utils;
-pub use vst3_com::co_class as VST3;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,5 @@ pub mod vst;
 pub use vst3_com::co_class as VST3;
 pub use vst3_com::REFIID;
 pub use vst3_com::*;
+pub mod utils;
+pub use vst3_com::co_class as VST3;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 //! Utilities for consumers of the raw API
-use vst3_com::{ComInterface, ComRc};
+use vst3_com::{ComInterface, ComPtr};
 
 /// A thin wrapper around a raw pointer to a vtable. Used in traits that return pointers to instances.
 #[repr(transparent)]
@@ -14,12 +14,12 @@ impl<I: ComInterface + ?Sized> VstPtr<I> {
         self.inst.is_null()
     }
     /// Promote the pointer to a reference count, returns `None` if the pointer is null.
-    pub fn upgrade(&self) -> Option<ComRc<I>> {
+    pub fn upgrade(&self) -> Option<ComPtr<I>> {
         if self.inst.is_null() {
             None
         } else {
             // Safety: we only guarantee the pointer is not null, if the code that allocated the pointer is flawed  it could still point to garbage.
-            unsafe { Some(ComRc::from_raw(self.inst)) }
+            unsafe { Some(ComPtr::new(self.inst)) }
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,13 +9,18 @@ pub struct VstPtr<I: ComInterface + ?Sized> {
 }
 
 impl<I: ComInterface + ?Sized> VstPtr<I> {
+    /// check if the underlying pointer is null
     pub fn is_null(&self) -> bool {
         self.inst.is_null()
     }
+    /// Promote the pointer to a reference count, returns `None` if the pointer is null. 
     pub fn upgrade(&self) -> Option<ComRc<I>> {
         if self.inst.is_null() {
             None
         } else {
+            // Safety: we only guarantee the pointer is not null, 
+            // if the code that allocated the pointer is flawed 
+            // it could still point to garbage.
             unsafe { Some(ComRc::from_raw(self.inst)) }
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,22 @@
+//! Utilities for consumers of the raw API
+use vst3_com::{ComInterface, ComRc};
+
+/// A thin wrapper around a raw pointer to a vtable. Used in traits that return pointers to instances.
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug)]
+pub struct VstPtr<I: ComInterface + ?Sized> {
+    inst: *mut *mut <I as ComInterface>::VTable,
+}
+
+impl<I: ComInterface + ?Sized> VstPtr<I> {
+    pub fn is_null(&self) -> bool {
+        self.inst.is_null()
+    }
+    pub fn upgrade(&self) -> Option<ComRc<I>> {
+        if self.inst.is_null() {
+            None
+        } else {
+            unsafe { Some(ComRc::from_raw(self.inst)) }
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,14 +13,12 @@ impl<I: ComInterface + ?Sized> VstPtr<I> {
     pub fn is_null(&self) -> bool {
         self.inst.is_null()
     }
-    /// Promote the pointer to a reference count, returns `None` if the pointer is null. 
+    /// Promote the pointer to a reference count, returns `None` if the pointer is null.
     pub fn upgrade(&self) -> Option<ComRc<I>> {
         if self.inst.is_null() {
             None
         } else {
-            // Safety: we only guarantee the pointer is not null, 
-            // if the code that allocated the pointer is flawed 
-            // it could still point to garbage.
+            // Safety: we only guarantee the pointer is not null, if the code that allocated the pointer is flawed  it could still point to garbage.
             unsafe { Some(ComRc::from_raw(self.inst)) }
         }
     }

--- a/src/vst/ivstattributes.rs
+++ b/src/vst/ivstattributes.rs
@@ -1,6 +1,8 @@
 use crate::base::{char8, tchar, tresult};
+use crate::utils::VstPtr;
 use vst3_com::interfaces::iunknown::IUnknown;
 use vst3_com::{c_void, com_interface};
+
 pub type AttrID = *const char8;
 
 #[com_interface("1E5F0AEB-CC7F-4533-A254-401138AD5EE4")]
@@ -18,5 +20,5 @@ pub trait IAttributeList: IUnknown {
 #[com_interface("D6CE2FFC-EFAF-4B8C-9E74-F1BB12DA44B4")]
 pub trait IStreamAttributes: IUnknown {
     unsafe fn get_filename(&self, name: *const tchar) -> tresult;
-    unsafe fn get_attributes(&self) -> *mut dyn IAttributeList;
+    unsafe fn get_attributes(&self) -> VstPtr<dyn IAttributeList>;
 }

--- a/src/vst/ivstaudioprocessor.rs
+++ b/src/vst/ivstaudioprocessor.rs
@@ -1,4 +1,5 @@
 use crate::base::{tresult, TBool};
+use crate::utils::VstPtr;
 use crate::vst::{
     BusDirection, CString, IEventList, IParameterChanges, ProcessContext, SpeakerArrangement,
 };
@@ -42,7 +43,6 @@ pub struct AudioBusBuffers {
 }
 
 #[repr(C)]
-#[derive(Debug)]
 pub struct ProcessData {
     pub process_mode: i32,
     pub symbolic_sample_size: i32,
@@ -51,10 +51,10 @@ pub struct ProcessData {
     pub num_outputs: i32,
     pub inputs: *mut AudioBusBuffers,
     pub outputs: *mut AudioBusBuffers,
-    pub input_param_changes: *mut dyn IParameterChanges,
-    pub output_param_changes: *mut dyn IParameterChanges,
-    pub input_events: *mut dyn IEventList,
-    pub output_events: *mut dyn IEventList,
+    pub input_param_changes: VstPtr<dyn IParameterChanges>,
+    pub output_param_changes: VstPtr<dyn IParameterChanges>,
+    pub input_events: VstPtr<dyn IEventList>,
+    pub output_events: VstPtr<dyn IEventList>,
     pub context: *mut ProcessContext,
 }
 

--- a/src/vst/ivstmessage.rs
+++ b/src/vst/ivstmessage.rs
@@ -1,4 +1,5 @@
 use crate::base::{tresult, FIDString};
+use crate::utils::VstPtr;
 use crate::vst::IAttributeList;
 use vst3_com::com_interface;
 use vst3_com::interfaces::iunknown::IUnknown;
@@ -7,12 +8,12 @@ use vst3_com::interfaces::iunknown::IUnknown;
 pub trait IMessage: IUnknown {
     unsafe fn get_message_id(&self) -> FIDString;
     unsafe fn set_message_id(&self, id: FIDString);
-    unsafe fn get_attributes(&self) -> *mut dyn IAttributeList;
+    unsafe fn get_attributes(&self) -> VstPtr<dyn IAttributeList>;
 }
 
 #[com_interface("70A4156F-6E6E-4026-9891-48BFAA60D8D1")]
 pub trait IConnectionPoint: IUnknown {
-    unsafe fn connect(&self, other: *mut dyn IConnectionPoint) -> tresult;
-    unsafe fn disconnect(&self, other: *mut dyn IConnectionPoint) -> tresult;
-    unsafe fn notify(&self, message: *mut dyn IMessage) -> tresult;
+    unsafe fn connect(&self, other: VstPtr<dyn IConnectionPoint>) -> tresult;
+    unsafe fn disconnect(&self, other: VstPtr<dyn IConnectionPoint>) -> tresult;
+    unsafe fn notify(&self, message: VstPtr<dyn IMessage>) -> tresult;
 }

--- a/src/vst/ivstparameterchanges.rs
+++ b/src/vst/ivstparameterchanges.rs
@@ -1,6 +1,7 @@
 use crate::base::tresult;
+use crate::utils::VstPtr;
+use vst3_com::com_interface;
 use vst3_com::interfaces::iunknown::IUnknown;
-use vst3_com::{c_void, com_interface};
 
 #[com_interface("01263A18-ED07-4F6F-98C9-D3564686F9BA")]
 pub trait IParamValueQueue: IUnknown {
@@ -14,7 +15,11 @@ pub trait IParamValueQueue: IUnknown {
 pub trait IParameterChanges: IUnknown {
     unsafe fn get_parameter_count(&self) -> i32;
     // Returns a pointer to IParamValueQueue
-    unsafe fn get_parameter_data(&self, index: i32) -> *mut c_void;
+    unsafe fn get_parameter_data(&self, index: i32) -> VstPtr<dyn IParamValueQueue>;
     // Returns a pointer to IParamValueQueue
-    unsafe fn add_parameter_data(&self, id: *const u32, index: *mut i32) -> *mut c_void;
+    unsafe fn add_parameter_data(
+        &self,
+        id: *const u32,
+        index: *mut i32,
+    ) -> VstPtr<dyn IParameterChanges>;
 }

--- a/src/vst/ivstunits.rs
+++ b/src/vst/ivstunits.rs
@@ -1,4 +1,5 @@
 use crate::base::{tchar, tresult, IBStream};
+use crate::utils::VstPtr;
 use crate::vst::{CString, String128};
 use vst3_com::com_interface;
 use vst3_com::interfaces::iunknown::IUnknown;
@@ -70,7 +71,7 @@ pub trait IUnitInfo: IUnknown {
         &self,
         list_or_unit: i32,
         program_idx: i32,
-        data: *mut dyn IBStream,
+        data: VstPtr<dyn IBStream>,
     ) -> tresult;
 }
 
@@ -81,14 +82,14 @@ pub trait IProgramListData: IUnknown {
         &self,
         list_id: i32,
         program_idx: i32,
-        stream: *mut dyn IBStream,
+        stream: VstPtr<dyn IBStream>,
     ) -> tresult;
-    unsafe fn set_program_data(&self, id: i32, idx: i32, stream: *mut dyn IBStream) -> tresult;
+    unsafe fn set_program_data(&self, id: i32, idx: i32, stream: VstPtr<dyn IBStream>) -> tresult;
 }
 
 #[com_interface("6C389611-D391-455D-B870-B83394A0EFDD")]
 pub trait IUnitData: IUnknown {
     unsafe fn unit_data_supported(&self, id: i32) -> tresult;
-    unsafe fn get_unit_data(&self, id: i32, data: *mut dyn IBStream) -> tresult;
-    unsafe fn set_unit_data(&self, id: i32, data: *mut dyn IBStream) -> tresult;
+    unsafe fn get_unit_data(&self, id: i32, data: VstPtr<dyn IBStream>) -> tresult;
+    unsafe fn set_unit_data(&self, id: i32, data: VstPtr<dyn IBStream>) -> tresult;
 }


### PR DESCRIPTION
This creates a `VstPtr` type which wraps a raw vtable pointer, and replaces the method calls and types that return pointers to interfaces with it. Consumers are required to do a `nullptr` check by upgrading to `ComRc` using `VstPtr::upgrade(&self)`, which returns `Option<ComRc>`. For example, in the `again` example:

```rust
        let param_changes: &VstPtr<IParameterChanges> = &(*data).input_param_changes;
        if let Some(param_changes) = param_changes.upgrade() {
            let num_params_changed: VstPtr<IParamValueQueue> = param_changes.get_parameter_count();
            for i in 0..num_params_changed {
                let param_queue = param_changes.get_parameter_data(i);
                if let Some(param_queue) = param_queue.upgrade() {
                   // ... 
```

The implementation is a transparent wrapper around a pointer to a vtable, which maintains the ABI. 

```rust
#[repr(transparent)]
pub struct VstPtr<I:ComInterface + ?Sized> {
   vtable: *mut I::VTable
}
```

The only difference between this and `ComPtr` is that we allow VstPtrs to be null, and check when upgrading. 