### PR TITLE
Make Bus-related types copyable/clonable

### DIFF
--- a/src/vst/ivstcomponent.rs
+++ b/src/vst/ivstcomponent.rs
@@ -4,17 +4,20 @@ use vst3_com::{c_void, com_interface, IID};
 
 pub const kDefaultFactoryFlags: i32 = FactoryFlags::kUnicode as i32;
 
+#[derive(Copy, Clone)]
 pub enum MediaTypes {
     kAudio = 0,
     kEvent = 1,
     kNumMediaTypes = 2,
 }
 
+#[derive(Copy, Clone)]
 pub enum BusDirections {
     kInput = 0,
     kOutput = 1,
 }
 
+#[derive(Copy, Clone)]
 pub enum BusTypes {
     kMain = 0,
     kAux = 1,
@@ -26,11 +29,13 @@ pub enum IoModes {
     kOfflineProcessing = 2,
 }
 
+#[derive(Copy, Clone)]
 pub enum BusFlags {
     kDefaultActive = 1,
 }
 
 #[repr(C)]
+#[derive(Copy, Clone)]
 pub struct BusInfo {
     pub media_type: i32,
     pub direction: i32,


### PR DESCRIPTION
Raw `BusInfo` is not convenient in Rust world because types are not Rust's enum. So I define bus information by define internal structure to denotes bus info with enum itself. But current vst3-sys implementation don't allow to copy or clone bus-related types so  move occurs at creating `BusInfo` from internal bus information.

This PR makes bus related types copyable/clonable, so we can treat these types in Rust way.