### PR TITLE
Fix velocity type

### DIFF
--- a/src/vst/ivstevents.rs
+++ b/src/vst/ivstevents.rs
@@ -21,7 +21,7 @@ pub struct NoteOnEvent {
     pub channel: i16,
     pub pitch: i16,
     pub tuning: f32,
-    pub velocity: i32,
+    pub velocity: f32,
     pub length: i32,
     pub note_id: i32,
 }
@@ -31,7 +31,7 @@ pub struct NoteOnEvent {
 pub struct NoteOffEvent {
     pub channel: i16,
     pub pitch: i16,
-    pub velocity: i32,
+    pub velocity: f32,
     pub length: i32,
     pub note_id: i32,
 }


### PR DESCRIPTION
Correct type of velocity is `f32`, not `i32`.
cf. [`velocity` in "VST 3 Interfaces: NoteOnEvent Struct Reference"](https://steinbergmedia.github.io/vst3_doc/vstinterfaces/structSteinberg_1_1Vst_1_1NoteOnEvent.html#ac46e821ae08930cc9e257642e34275a3)