### PR TITLE
Fix VST3 attribute macro expension for structs with generics, comments, and attributes

### DIFF
--- a/com/macros/support/src/aggr_co_class/class_factory.rs
+++ b/com/macros/support/src/aggr_co_class/class_factory.rs
@@ -11,6 +11,8 @@ pub fn generate(struct_item: &ItemStruct) -> HelperTokenStream {
 
     let struct_ident = &struct_item.ident;
     let class_factory_ident = crate::utils::class_factory_ident(&struct_ident);
+    let (class_factory_impl_generics, class_factory_ty_generics, class_factory_where_clause) =
+        struct_item.generics.split_for_impl();
 
     let struct_definition =
         crate::co_class::class_factory::gen_class_factory_struct_definition(&class_factory_ident);
@@ -19,16 +21,18 @@ pub fn generate(struct_item: &ItemStruct) -> HelperTokenStream {
         &base_interface_idents,
         &aggr_map,
         &class_factory_ident,
+        &class_factory_ty_generics,
     );
     let class_factory_impl = crate::co_class::class_factory::gen_class_factory_impl(
         &base_interface_idents,
         &class_factory_ident,
+        &class_factory_ty_generics,
     );
 
     quote! {
         #struct_definition
 
-        impl vst3_com::interfaces::IClassFactory for #class_factory_ident {
+        impl #class_factory_impl_generics vst3_com::interfaces::IClassFactory for #class_factory_ident #class_factory_ty_generics #class_factory_where_clause {
             unsafe fn create_instance(
                 &self,
                 aggr: *mut *const <dyn vst3_com::interfaces::iunknown::IUnknown as vst3_com::ComInterface>::VTable,

--- a/com/macros/support/src/aggr_co_class/com_struct.rs
+++ b/com/macros/support/src/aggr_co_class/com_struct.rs
@@ -14,6 +14,7 @@ pub fn generate(
 ) -> HelperTokenStream {
     let struct_ident = &struct_item.ident;
     let vis = &struct_item.vis;
+    let generics = &struct_item.generics;
 
     let base_fields = co_class::com_struct::gen_base_fields(base_interface_idents);
     let ref_count_field = co_class::com_struct::gen_ref_count_field();
@@ -26,7 +27,7 @@ pub fn generate(
 
     quote!(
         #[repr(C)]
-        #vis struct #struct_ident {
+        #vis struct #struct_ident #generics {
             #base_fields
             #non_delegating_iunknown_field_ident: *const <dyn vst3_com::interfaces::iunknown::IUnknown as vst3_com::ComInterface>::VTable,
             // Non-reference counted interface pointer to outer IUnknown.

--- a/com/macros/support/src/aggr_co_class/iunknown_impl.rs
+++ b/com/macros/support/src/aggr_co_class/iunknown_impl.rs
@@ -7,11 +7,13 @@ use syn::ItemStruct;
 /// delegate to the interface pointer at __iunknown_to_use.
 pub fn generate(struct_item: &ItemStruct) -> HelperTokenStream {
     let struct_ident = &struct_item.ident;
+    let (impl_generics, ty_generics, where_clause) = struct_item.generics.split_for_impl();
+
     let iunknown_to_use_field_ident = crate::utils::iunknown_to_use_field_ident();
     let ptr_casting = quote! { as *mut _ };
 
     quote!(
-        impl vst3_com::interfaces::IUnknown for #struct_ident {
+        impl #impl_generics vst3_com::interfaces::IUnknown for #struct_ident #ty_generics #where_clause {
             unsafe fn query_interface(
                 &self,
                 riid: *const vst3_com::sys::IID,

--- a/com/macros/support/src/co_class/co_class_impl.rs
+++ b/com/macros/support/src/co_class/co_class_impl.rs
@@ -4,9 +4,10 @@ use syn::ItemStruct;
 
 pub fn generate(struct_item: &ItemStruct) -> HelperTokenStream {
     let struct_ident = &struct_item.ident;
+    let (impl_generics, ty_generics, where_clause) = struct_item.generics.split_for_impl();
 
     quote! {
-        unsafe impl vst3_com::CoClass for #struct_ident {
+        unsafe impl #impl_generics vst3_com::CoClass for #struct_ident #ty_generics #where_clause {
         }
     }
 }

--- a/com/macros/support/src/co_class/com_struct.rs
+++ b/com/macros/support/src/co_class/com_struct.rs
@@ -17,6 +17,7 @@ pub fn generate<S: ::std::hash::BuildHasher>(
 ) -> HelperTokenStream {
     let struct_ident = &struct_item.ident;
     let vis = &struct_item.vis;
+    let generics = &struct_item.generics;
 
     let base_fields = gen_base_fields(base_interface_idents);
     let ref_count_field = gen_ref_count_field();
@@ -25,7 +26,7 @@ pub fn generate<S: ::std::hash::BuildHasher>(
 
     quote!(
         #[repr(C)]
-        #vis struct #struct_ident {
+        #vis struct #struct_ident #generics {
             #base_fields
             #ref_count_field
             #aggregate_fields

--- a/com/macros/support/src/co_class/com_struct_impl.rs
+++ b/com/macros/support/src/co_class/com_struct_impl.rs
@@ -67,10 +67,16 @@ pub fn gen_allocate_fn<S: ::std::hash::BuildHasher>(
 }
 
 pub fn gen_allocate_function_parameters_signature(struct_item: &ItemStruct) -> HelperTokenStream {
-    let fields = match &struct_item.fields {
-        Fields::Named(f) => &f.named,
+    let mut fields = match &struct_item.fields {
+        Fields::Named(f) => f.named.clone(),
         _ => panic!("Found non Named fields in struct."),
     };
+
+    // Attributes and comments need to be stripped out since those are not vallid in the middle of a
+    // function signature
+    for field in fields.iter_mut() {
+        field.attrs.clear();
+    }
 
     quote!(#fields)
 }

--- a/com/macros/support/src/co_class/com_struct_impl.rs
+++ b/com/macros/support/src/co_class/com_struct_impl.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream as HelperTokenStream;
 use quote::{format_ident, quote};
 use std::collections::HashMap;
-use syn::{Fields, Ident, ItemStruct};
+use syn::{Fields, Ident, ItemStruct, TypeGenerics};
 
 pub fn generate<S: ::std::hash::BuildHasher>(
     aggr_map: &HashMap<Ident, Vec<Ident>, S>,
@@ -9,6 +9,7 @@ pub fn generate<S: ::std::hash::BuildHasher>(
     struct_item: &ItemStruct,
 ) -> HelperTokenStream {
     let struct_ident = &struct_item.ident;
+    let (impl_generics, ty_generics, where_clause) = struct_item.generics.split_for_impl();
 
     let allocate_fn = gen_allocate_fn(aggr_map, base_interface_idents, struct_item);
     let set_aggregate_fns = gen_set_aggregate_fns(aggr_map);
@@ -17,7 +18,7 @@ pub fn generate<S: ::std::hash::BuildHasher>(
     //let get_class_object_fn = gen_get_class_object_fn(struct_item);
 
     quote!(
-        impl #struct_ident {
+        impl #impl_generics #struct_ident #ty_generics #where_clause {
             #allocate_fn
 
             // Removing some bloat
@@ -35,8 +36,9 @@ pub fn gen_allocate_fn<S: ::std::hash::BuildHasher>(
     struct_item: &ItemStruct,
 ) -> HelperTokenStream {
     let struct_ident = &struct_item.ident;
+    let (_, ty_generics, _) = struct_item.generics.split_for_impl();
 
-    let base_inits = gen_allocate_base_inits(struct_ident, base_interface_idents);
+    let base_inits = gen_allocate_base_inits(struct_ident, &ty_generics, base_interface_idents);
 
     // Allocate function signature
     let allocate_parameters = gen_allocate_function_parameters_signature(struct_item);
@@ -50,7 +52,7 @@ pub fn gen_allocate_fn<S: ::std::hash::BuildHasher>(
 
     // Initialise all aggregated objects as NULL.
     quote!(
-        fn allocate(#allocate_parameters) -> Box<#struct_ident> {
+        fn allocate(#allocate_parameters) -> Box<#struct_ident #ty_generics> {
             #base_inits
 
             let out = #struct_ident {
@@ -120,6 +122,7 @@ pub fn gen_allocate_base_fields(base_interface_idents: &[Ident]) -> HelperTokenS
 // Initialise VTables with the correct adjustor thunks, through the vtable! macro.
 pub fn gen_allocate_base_inits(
     struct_ident: &Ident,
+    ty_generics: &TypeGenerics,
     base_interface_idents: &[Ident],
 ) -> HelperTokenStream {
     let mut offset_count: usize = 0;
@@ -130,7 +133,7 @@ pub fn gen_allocate_base_inits(
         // struct_ident: #base, $offset_count 
         let offset_ident = format_ident!("Offset{}", offset_count);
         let out = quote!(
-            let #vtable_var_ident = vst3_com::vtable!(#struct_ident: #base, vst3_com::#offset_ident);
+            let #vtable_var_ident = vst3_com::vtable!(#struct_ident #ty_generics: #base, vst3_com::#offset_ident);
             let #vptr_field_ident = Box::into_raw(Box::new(#vtable_var_ident));
         );
 

--- a/com/src/lib.rs
+++ b/com/src/lib.rs
@@ -83,8 +83,8 @@ pub trait ProductionComInterface<T: IUnknown>: ComInterface {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! vtable {
-    ($class:ident$( <$generics:tt>)?: $interface:ident, $offset:path) => {
-        <dyn $interface as $crate::ProductionComInterface<$class$( <$generics>)?>>::vtable::<$offset>();
+    ($class:ty: $interface:ident, $offset:path) => {
+        <dyn $interface as $crate::ProductionComInterface<$class>>::vtable::<$offset>();
     };
 }
 

--- a/com/src/lib.rs
+++ b/com/src/lib.rs
@@ -83,8 +83,8 @@ pub trait ProductionComInterface<T: IUnknown>: ComInterface {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! vtable {
-    ($class:ident: $interface:ident, $offset:path) => {
-        <dyn $interface as $crate::ProductionComInterface<$class>>::vtable::<$offset>();
+    ($class:ident$( <$generics:tt>)?: $interface:ident, $offset:path) => {
+        <dyn $interface as $crate::ProductionComInterface<$class$( <$generics>)?>>::vtable::<$offset>();
     };
 }
 


### PR DESCRIPTION
I was working on a small plugin framework, and I noticed that the macro expansion would fail in mysterious ways when the struct the `#[VST3]` attribute is applied on has generics. Putting comments inside of the struct or attaching attributes to the fields would also result in similar compiler errors because the generated allocate function would be malformed (with comments inside of the parameter list). This fixes the macro expansion for structs like these:

```rust
#[VST3(implements(IPluginFactory))]
pub struct Factory<P: Plugin> {
    /// The type will be used for constructing plugin instances later.
    _phantom: PhantomData<P>,
}
```