### PR TITLE
Use atomics for the internal reference count

### DIFF
--- a/com/macros/support/src/co_class/com_struct.rs
+++ b/com/macros/support/src/co_class/com_struct.rs
@@ -45,7 +45,7 @@ pub fn gen_base_fields(base_interface_idents: &[Ident]) -> HelperTokenStream {
 
 pub fn gen_ref_count_field() -> HelperTokenStream {
     let ref_count_ident = crate::utils::ref_count_ident();
-    quote!(#ref_count_ident: std::cell::Cell<u32>,)
+    quote!(#ref_count_ident: std::sync::atomic::AtomicU32,)
 }
 
 pub fn gen_aggregate_fields<S: ::std::hash::BuildHasher>(

--- a/com/macros/support/src/co_class/com_struct_impl.rs
+++ b/com/macros/support/src/co_class/com_struct_impl.rs
@@ -105,7 +105,7 @@ pub fn gen_allocate_user_fields(struct_item: &ItemStruct) -> HelperTokenStream {
 pub fn gen_allocate_ref_count_field() -> HelperTokenStream {
     let ref_count_ident = crate::utils::ref_count_ident();
     quote!(
-        #ref_count_ident: std::cell::Cell::new(1),
+        #ref_count_ident: std::sync::atomic::AtomicU32::new(1),
     )
 }
 

--- a/com/macros/support/src/co_class/com_struct_impl.rs
+++ b/com/macros/support/src/co_class/com_struct_impl.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream as HelperTokenStream;
 use quote::{format_ident, quote};
 use std::collections::HashMap;
-use syn::{Fields, Ident, ItemStruct, TypeGenerics};
+use syn::{Fields, Ident, ItemStruct, TypeGenerics, Visibility};
 
 pub fn generate<S: ::std::hash::BuildHasher>(
     aggr_map: &HashMap<Ident, Vec<Ident>, S>,
@@ -66,10 +66,13 @@ pub fn gen_allocate_function_parameters_signature(struct_item: &ItemStruct) -> H
         _ => panic!("Found non Named fields in struct."),
     };
 
-    // Attributes and comments need to be stripped out since those are not vallid in the middle of a
-    // function signature
     for field in fields.iter_mut() {
+        // Attributes and comments need to be stripped out since those are not vallid in the middle of a
+        // function signature
         field.attrs.clear();
+
+        // Visibility specifiers should obviously also not go in a function signature
+        field.vis = Visibility::Inherited;
     }
 
     quote!(#fields)

--- a/src/vst/ivstparameterchanges.rs
+++ b/src/vst/ivstparameterchanges.rs
@@ -21,5 +21,5 @@ pub trait IParameterChanges: IUnknown {
         &self,
         id: *const u32,
         index: *mut i32,
-    ) -> StaticVstPtr<dyn IParameterChanges>;
+    ) -> StaticVstPtr<dyn IParamValueQueue>;
 }


### PR DESCRIPTION
This mirrors the VST3 SDK's implementation. In practice using regular integers will not cause any issues since the host will _usually_ not query and destroy interface objects from different threads at the same time, but when using atomics those situations where that does happen are also safe.