### PR TITLE
Fix NoteOffEvent struct fields

### DIFF
--- a/src/vst/ivstevents.rs
+++ b/src/vst/ivstevents.rs
@@ -32,8 +32,8 @@ pub struct NoteOffEvent {
     pub channel: i16,
     pub pitch: i16,
     pub velocity: f32,
-    pub length: i32,
     pub note_id: i32,
+    pub tuning: f32,
 }
 
 #[repr(C)]


### PR DESCRIPTION
See https://github.com/steinbergmedia/vst3_pluginterfaces/blob/2ad397ade5b51007860bedb3b01b8afd2c5f6fba/vst/ivstevents.h#L53-L64 for the original definition. There are also a lot of missing constants everywhere but I've been declaring them inline in NIH-plug for the time being.