### PR TITLE
Add GPLv3 as license to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vst3-sys"
 version = "0.1.0"
 authors = ["Mike Hilgendorf <mike@hilgendorf.audio>", "Mirko Covizzi <mrkcvzz@gmail.com>"]
+license = "GPLv3"
 description = """
 Pure Rust bindings to the VST3 APIs, based on COM. 
 """


### PR DESCRIPTION
This makes the viral license obvious to users which check licensing via the [cargo-license](https://crates.io/crates/cargo-license) tool.