### PR TITLE
Explicitly drop Box::from_raw result to fix unused result warnings

### DIFF
--- a/com/macros/support/src/aggr_co_class/com_struct_impl.rs
+++ b/com/macros/support/src/aggr_co_class/com_struct_impl.rs
@@ -120,7 +120,7 @@ pub fn gen_inner_release(
 fn gen_non_delegating_iunknown_drop() -> HelperTokenStream {
     let non_delegating_iunknown_field_ident = crate::utils::non_delegating_iunknown_field_ident();
     quote!(
-        Box::from_raw(self.#non_delegating_iunknown_field_ident as *mut <dyn vst3_com::interfaces::iunknown::IUnknown as vst3_com::ComInterface>::VTable);
+        drop(Box::from_raw(self.#non_delegating_iunknown_field_ident as *mut <dyn vst3_com::interfaces::iunknown::IUnknown as vst3_com::ComInterface>::VTable));
     )
 }
 

--- a/com/macros/support/src/co_class/iunknown_impl.rs
+++ b/com/macros/support/src/co_class/iunknown_impl.rs
@@ -107,7 +107,7 @@ fn gen_vptr_drops(base_interface_idents: &[Ident]) -> HelperTokenStream {
     let vptr_drops = base_interface_idents.iter().map(|base| {
         let vptr_field_ident = crate::utils::vptr_field_ident(base);
         quote!(
-            Box::from_raw(self.#vptr_field_ident as *mut <dyn #base as vst3_com::ComInterface>::VTable);
+            drop(Box::from_raw(self.#vptr_field_ident as *mut <dyn #base as vst3_com::ComInterface>::VTable));
         )
     });
 
@@ -116,7 +116,7 @@ fn gen_vptr_drops(base_interface_idents: &[Ident]) -> HelperTokenStream {
 
 fn gen_com_object_drop(struct_ident: &Ident, ty_generics: &TypeGenerics) -> HelperTokenStream {
     quote!(
-        Box::from_raw(self as *const _ as *mut #struct_ident #ty_generics);
+        drop(Box::from_raw(self as *const _ as *mut #struct_ident #ty_generics));
     )
 }
 


### PR DESCRIPTION
This has been happening since June/July. `Box::from_raw` has a `#[must_use]` attribute and thus needs to either be bound to a binding or dropped explicitly.