### PR TITLE
Format GPL version correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vst3-sys"
 version = "0.1.0"
 authors = ["Mike Hilgendorf <mike@hilgendorf.audio>", "Mirko Covizzi <mrkcvzz@gmail.com>"]
-license = "GPLv3"
+license = "GPL-3.0"
 description = """
 Pure Rust bindings to the VST3 APIs, based on COM. 
 """


### PR DESCRIPTION
The license should be formatted according to https://spdx.github.io/license-list-data/.